### PR TITLE
Fix some compatible issue

### DIFF
--- a/FlvStream2File/AmfEncoderDecoder.cs
+++ b/FlvStream2File/AmfEncoderDecoder.cs
@@ -181,13 +181,25 @@ namespace FlvStream2File
             string onMeta = DecodeVal(buff) as string;
             // read array type
             byte type = buff[_readHead++];
-            Debug.Assert(type == (byte)AMFTypes.Array);
-            byte[] alen = new byte[sizeof(int)];
-            Buffer.BlockCopy(buff, _readHead, alen, 0, alen.Length);
-            _readHead += alen.Length;
-            int arrayLen = BitConverter.ToInt32(alen.Reverse().ToArray(), 0);
-            Debug.Write(string.Format("onMetaData Array Len: {0}\n", arrayLen));           
-            while (_readHead <= buff.Length-1)  
+            Debug.Assert(type == (byte)AMFTypes.Array || type == (byte)AMFTypes.Object);
+            if(type == (byte)AMFTypes.Array)
+            {
+                byte[] alen = new byte[sizeof(int)];
+                Buffer.BlockCopy(buff, _readHead, alen, 0, alen.Length);
+                _readHead += alen.Length;
+                int arrayLen = BitConverter.ToInt32(alen.Reverse().ToArray(), 0);
+                Debug.Write(string.Format("onMetaData Array Len: {0}\n", arrayLen));
+            }
+            else if(type == (byte)AMFTypes.Object)
+            {
+                // Do nothing. Just fine.
+                Debug.Write("onMetaData isn't an Array but Object!\n");
+            }
+            else
+            {
+                //TODO: Maybe throw a exception
+            }
+            while(_readHead <= buff.Length - 1)
             {
                 string key = DecodeKey(buff);
                 DebugOrder.Add(key);


### PR DESCRIPTION
Tested it and turned out when stream using OBS Classic, the onMetaData part isn't an Array but Object. Not sure why. Recorded file with OBS Classic is just fine. Maybe it's a server side thing.
Also not sure if you want to merge this or not, if you don't like it, just close it. 😄
Thanks for the project.